### PR TITLE
fix: 修复 LYMod 面板鼠标穿透

### DIFF
--- a/LongYinLiZhiZhuan/LYMod/Main.cs
+++ b/LongYinLiZhiZhuan/LYMod/Main.cs
@@ -93,10 +93,11 @@ public class Plugin : MelonMod
     private Vector2 mainScrollPos;
     private const float Hight = 1000;
     private const int Width = 590;
-    public Rect MainWindowRect = new(50, 50, Width, Hight);
-    public bool ShowMainWindow = false;
+    private Rect _mainWindowRect = new(50, 50, Width, Hight);
+    private bool _showMainWindow;
     private readonly string[] tabNames = { "功能开关", "测试", "属性ID", "门派特性" };
     private int selectedTab;
+    private bool _isCapturingMainWindowPointer;
     
     
     public override void OnInitializeMelon()
@@ -213,21 +214,22 @@ public class Plugin : MelonMod
     }
     public override void OnUpdate()
     {
-        // 左alt + e 打开窗体
+        // Alt+E 切换主面板
         if (IsOpenWindowTriggered())
         {
-            ShowMainWindow = !ShowMainWindow;
+            _showMainWindow = !_showMainWindow;
+            _isCapturingMainWindowPointer = false;
             
             OtherElement.RefreshForceList();
             var hero = HeroDetailController._instance;
-            if (hero != null && ShowMainWindow)
+            if (hero != null && _showMainWindow)
             {
                 TestElement.ReadedHeroData = hero.nowShowHero;
                 TestElement.LoadHorseData();
             }
         }
 
-        // 按R开始Roll
+        // 按 R 重刷几个可复用的 Roll 场景
         if (Input.GetKeyDown(KeyCode.R) && _breakRollFlag.Value)
         {
             TryBreakThoughtRoll();
@@ -269,24 +271,97 @@ public class Plugin : MelonMod
         GUI.skin.button.fontSize = scaledFontSize;
         GUI.skin.toggle.fontSize = scaledFontSize;
         GUI.skin.textField.fontSize = scaledFontSize;
-        
-        if (ShowMainWindow)
+
+        if (!_showMainWindow)
         {
-            var scaledWidth = 590 * scale;
-            var scaledHeight = Hight * scale;
-            MainWindowRect = new Rect(MainWindowRect.x, MainWindowRect.y, scaledWidth, scaledHeight);
-            MainWindowRect = GUI.ModalWindow(0, MainWindowRect, (GUI.WindowFunction)DrawMainWindow, "LYMod " + ModConstants.ModVersion);
+            _isCapturingMainWindowPointer = false;
+            return;
+        }
+
+        var currentEvent = Event.current;
+        // IMGUI 先决定这次鼠标事件是否由 MOD 窗口接管
+        var shouldConsumePointerEvent = UpdateMainWindowPointerCapture(currentEvent);
+        var scaledWidth = Width * scale;
+        var scaledHeight = Hight * scale;
+        _mainWindowRect = new Rect(_mainWindowRect.x, _mainWindowRect.y, scaledWidth, scaledHeight);
+        _mainWindowRect = GUI.ModalWindow(0, _mainWindowRect, (GUI.WindowFunction)DrawMainWindow, "LYMod " + ModConstants.ModVersion);
+
+        if (shouldConsumePointerEvent && currentEvent != null)
+        {
+            // 只消费当前已由 IMGUI 面板接管的鼠标事件，键盘不在这里处理
+            currentEvent.Use();
+        }
+    }
+
+    public bool ShouldBlockGamePointerInput()
+    {
+        return _showMainWindow && (_isCapturingMainWindowPointer || IsPointerInsideMainWindow(ToGuiMousePosition(Input.mousePosition)));
+    }
+
+    private static Vector2 ToGuiMousePosition(Vector3 mousePosition)
+    {
+        return new Vector2(mousePosition.x, Screen.height - mousePosition.y);
+    }
+
+    private bool IsPointerInsideMainWindow(Vector2 guiMousePosition)
+    {
+        return _showMainWindow && _mainWindowRect.Contains(guiMousePosition);
+    }
+
+    private bool UpdateMainWindowPointerCapture(Event currentEvent)
+    {
+        if (!_showMainWindow)
+        {
+            _isCapturingMainWindowPointer = false;
+            return false;
+        }
+
+        if (currentEvent == null)
+        {
+            return false;
+        }
+
+        var isInsideWindow = IsPointerInsideMainWindow(currentEvent.mousePosition);
+        switch (currentEvent.type)
+        {
+            case EventType.MouseDown:
+                // 在窗内按下后，直到 MouseUp 前都持续认为由窗口接管
+                if (isInsideWindow)
+                {
+                    _isCapturingMainWindowPointer = true;
+                    return true;
+                }
+                return false;
+            case EventType.MouseDrag:
+                if (_isCapturingMainWindowPointer || isInsideWindow)
+                {
+                    _isCapturingMainWindowPointer = true;
+                    return true;
+                }
+                return false;
+            case EventType.MouseMove:
+            case EventType.ContextClick:
+            case EventType.ScrollWheel:
+                return _isCapturingMainWindowPointer || isInsideWindow;
+            case EventType.MouseUp:
+            {
+                var shouldBlock = _isCapturingMainWindowPointer || isInsideWindow;
+                _isCapturingMainWindowPointer = false;
+                return shouldBlock;
+            }
+            default:
+                return false;
         }
     }
 
     private void DrawMainWindow(int windowId)
     {
         var scale = WindowScaling.Value;
-        var scaledWidth = 560 * scale;
+        var scaledWidth = (Width - 30) * scale;
         var scaledHeight = (Hight * scale) - (70 * scale);
        
         GUILayout.Space(5 * scale);
-        // 标签页选择
+        // 标签页
         GUILayout.BeginHorizontal();
         for (var i = 0; i < tabNames.Length; i++)
         {
@@ -295,32 +370,29 @@ public class Plugin : MelonMod
         }
 
         GUILayout.EndHorizontal();
-       
-
-        // 滚动区域
+        // 主滚动区域
         mainScrollPos = GUILayout.BeginScrollView(mainScrollPos, GUILayout.Width(scaledWidth), GUILayout.Height(scaledHeight));
         
-        // 根据选择的标签页绘制不同内容
+        // 根据标签页绘制内容
         switch (selectedTab)
         {
-            case 0: // 功能
+            case 0: // 功能开关
                 DrawMainTab();
                 break;
-            case 1:// 测试
+            case 1: // 测试
                 TestElement.TestTab(); 
                 break;
-            case 2: //属性id
+            case 2: // 属性ID
                 OtherElement.Label();
                 break;
-            case 3: //帮派特性选择
+            case 3: // 门派特性
                 OtherElement.ForceSpeFunction();
                 break;
         }
 
         GUILayout.EndScrollView();
-        // 启用窗口拖拽（仅标题栏区域）
-        // GUI.DragWindow(new Rect(0, 0, Screen.width, 20));
-        GUI.DragWindow(new Rect(0, 0, MainWindowRect.width, MainWindowRect.height));
+        // 允许直接拖动 MOD 窗口
+        GUI.DragWindow(new Rect(0, 0, _mainWindowRect.width, _mainWindowRect.height));
     }
 
     private void DrawMainTab()
@@ -984,6 +1056,5 @@ public class Plugin : MelonMod
     //         pc.FindSpeSteleFight();
     //     }
     // }
-  
 }
 

--- a/LongYinLiZhiZhuan/LYMod/UIPatches.cs
+++ b/LongYinLiZhiZhuan/LYMod/UIPatches.cs
@@ -1,55 +1,188 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Il2Cpp;
 using UnityEngine;
 
 namespace LYMod;
 
 [HarmonyPatch]
-public class UIPatches
+public static class UIPatches
 {
-
-    private static bool IsMouseOverIMGUI()
+    // Game/UI click paths vary, so pointer blocking stays at the Unity input layer.
+    private static bool AllowGamePointerInput()
     {
-        if (Plugin.Instance.ShowMainWindow)
+        if (Plugin.Instance == null || !Plugin.Instance.ShouldBlockGamePointerInput())
         {
-            Vector2 guiMousePos = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y);
-            if (Plugin.Instance.MainWindowRect.Contains(guiMousePos))
-            {
-                return true;
-            }
+            return true;
         }
+
+        UICamera.hoveredObject = null;
+        MouseController.hoveredObject = null;
         return false;
     }
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(MouseController), "Update")]
-    public static bool MouseController_Update_Prefix(MouseController __instance)
+
+    // 鼠标按键类输入统一返回 false，避免点击穿透到游戏
+    private static bool TryBlockMouseButton(ref bool result)
     {
-        return !IsMouseOverIMGUI();
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        result = false;
+        return false;
     }
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(GameController), "Update")]
-    public static bool GameController_Update_Prefix(GameController __instance)
+
+    // 只拦鼠标轴，其他轴仍交给游戏
+    private static bool TryBlockMouseAxis(string axisName, ref float result)
     {
-        return !IsMouseOverIMGUI();
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        if (axisName is "Mouse X" or "Mouse Y" or "Mouse ScrollWheel")
+        {
+            result = 0f;
+            return false;
+        }
+
+        return true;
     }
-    
-    
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(BuildQuickButtonController), nameof(BuildQuickButtonController.OnClick))]
-    public static bool BuildQuickButtonController_OnClick_Prefix(BuildQuickButtonController __instance)
+
+    // 一些界面会把鼠标左/右/中键映射成 Fire 按钮
+    private static bool TryBlockFireButton(string buttonName, ref bool result)
     {
-        return !IsMouseOverIMGUI();
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        if (buttonName is "Fire1" or "Fire2" or "Fire3")
+        {
+            result = false;
+            return false;
+        }
+
+        return true;
     }
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(HeroIconController), nameof(HeroIconController.OnClick))]
-    public static bool HeroIconController_OnClick_Prefix(HeroIconController __instance)
+
+    private static bool IsMouseKeyCode(KeyCode keyCode)
     {
-        return !IsMouseOverIMGUI();
+        return keyCode is KeyCode.Mouse0 or KeyCode.Mouse1 or KeyCode.Mouse2 or KeyCode.Mouse3 or KeyCode.Mouse4
+            or KeyCode.Mouse5 or KeyCode.Mouse6;
     }
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(ShowHeroDetail), nameof(ShowHeroDetail.OnClick))]
-    public static bool ShowHeroDetail_OnClick_Prefix(ShowHeroDetail __instance)
+
+    // 部分逻辑走 GetKey(Mouse0/1/2...)，这里一起兜住
+    private static bool TryBlockMouseKey(KeyCode keyCode, ref bool result)
     {
-        return !IsMouseOverIMGUI();
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        if (IsMouseKeyCode(keyCode))
+        {
+            result = false;
+            return false;
+        }
+
+        return true;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetMouseButton))]
+    public static bool Input_GetMouseButton_Prefix(ref bool __result)
+    {
+        return TryBlockMouseButton(ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetMouseButtonDown))]
+    public static bool Input_GetMouseButtonDown_Prefix(ref bool __result)
+    {
+        return TryBlockMouseButton(ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetMouseButtonUp))]
+    public static bool Input_GetMouseButtonUp_Prefix(ref bool __result)
+    {
+        return TryBlockMouseButton(ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetAxis))]
+    public static bool Input_GetAxis_Prefix(string axisName, ref float __result)
+    {
+        return TryBlockMouseAxis(axisName, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetAxisRaw))]
+    public static bool Input_GetAxisRaw_Prefix(string axisName, ref float __result)
+    {
+        return TryBlockMouseAxis(axisName, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetButton))]
+    public static bool Input_GetButton_Prefix(string buttonName, ref bool __result)
+    {
+        return TryBlockFireButton(buttonName, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetButtonDown))]
+    public static bool Input_GetButtonDown_Prefix(string buttonName, ref bool __result)
+    {
+        return TryBlockFireButton(buttonName, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetButtonUp))]
+    public static bool Input_GetButtonUp_Prefix(string buttonName, ref bool __result)
+    {
+        return TryBlockFireButton(buttonName, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetKey), typeof(KeyCode))]
+    public static bool Input_GetKey_Prefix(KeyCode key, ref bool __result)
+    {
+        return TryBlockMouseKey(key, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetKeyDown), typeof(KeyCode))]
+    public static bool Input_GetKeyDown_Prefix(KeyCode key, ref bool __result)
+    {
+        return TryBlockMouseKey(key, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.GetKeyUp), typeof(KeyCode))]
+    public static bool Input_GetKeyUp_Prefix(KeyCode key, ref bool __result)
+    {
+        return TryBlockMouseKey(key, ref __result);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Input), nameof(Input.mouseScrollDelta), MethodType.Getter)]
+    public static bool Input_mouseScrollDelta_Prefix(ref Vector2 __result)
+    {
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        __result = Vector2.zero;
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SendMouseEvents), nameof(SendMouseEvents.DoSendMouseEvents))]
+    public static bool SendMouseEvents_DoSendMouseEvents_Prefix()
+    {
+        return AllowGamePointerInput();
     }
 }


### PR DESCRIPTION
重做 Alt+E IMGUI 面板的指针接管逻辑，仅当窗口显示且鼠标位于窗口内，或仍处于同一次按下/拖拽/滚轮交互过程中时，才拦截游戏鼠标输入。

Main.cs 中将窗口显隐与 Rect 状态收口为私有字段，补充鼠标捕获状态维护，覆盖 MouseDown、MouseDrag、MouseUp、ScrollWheel，并在 GUI.ModalWindow 绘制后只消费已由面板接管的鼠标事件；同时保留原有标签页结构和原作者注释，方便后续阅读。

UIPatches.cs 删除原先粗粒度的 MouseController/GameController 拦截，改为在 Unity 输入层补丁 Input 的鼠标、按钮、按键接口以及 SendMouseEvents.DoSendMouseEvents，从而阻止点击、拖拽和滚轮继续传到游戏界面，同时保持窗口外点击仍可正常操作游戏。
