### PR TITLE
fix: 改用 BuildQuickButtonController.Update 处理 LYMod 窗口后的建筑快捷按钮悬停

### DIFF
--- a/LongYinLiZhiZhuan/LYMod/UIPatches.cs
+++ b/LongYinLiZhiZhuan/LYMod/UIPatches.cs
@@ -8,12 +8,23 @@ namespace LYMod;
 public static class UIPatches
 {
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(BuildQuickButtonController), nameof(BuildQuickButtonController.OnPointerEnter))]
-    public static bool BuildQuickButtonController_OnPointerEnter(ref BuildQuickButtonController __instance)
+    [HarmonyPatch(typeof(BuildQuickButtonController), nameof(BuildQuickButtonController.Update))]
+    public static bool BuildQuickButtonController_Update(BuildQuickButtonController __instance)
     {
-        return AllowGamePointerInput();
+        if (AllowGamePointerInput())
+        {
+            return true;
+        }
+
+        if (__instance != null)
+        {
+            __instance.onHover = false;
+            __instance.hoverTime = 0f;
+        }
+
+        return false;
     }
-    
+
     // Game/UI click paths vary, so pointer blocking stays at the Unity input layer.
     private static bool AllowGamePointerInput()
     {


### PR DESCRIPTION
这个 PR 修了 LYMod 窗口相关的一处崩溃和一处悬停穿透问题。

之前把补丁挂在 BuildQuickButtonController.OnPointerEnter 上时，游戏在某些悬停路径下会直接卡住闪退。实际排查后，崩溃点固定落在 GameAssembly.dll + 0xB0CE6F，对应的正好是 BuildQuickButtonController.OnPointerEnter 这段很小的原生函数尾部位置，所以这里不再继续 patch OnPointerEnter。

现在改成在 BuildQuickButtonController.Update 里处理。LYMod 没接管鼠标时，保持游戏原逻辑不变；LYMod 接管鼠标时，清掉按钮的悬停状态并跳过原更新。这样既绕开了原来的崩溃点，也保留了窗口打开时对后方建筑快捷按钮的阻断效果。