### PR TITLE
优化传授任意技能的功能与传授满级功能

### DIFF
--- a/LongYinLiZhiZhuan/LYMod/HarmonyPatches.cs
+++ b/LongYinLiZhiZhuan/LYMod/HarmonyPatches.cs
@@ -379,8 +379,6 @@ public class BookWriterDataPatches
 
 public class ChooseControllerPatches
 {
-    private static HeroData targetHero;
-    
     // 金龙生刷新购买情报
     [HarmonyPostfix]
     [HarmonyPatch(typeof(HeroIconController), nameof(HeroIconController.OnClick))]
@@ -392,7 +390,6 @@ public class ChooseControllerPatches
             if (hero != null)
             {
                 GameController.Instance.worldData.monthBuyAreaInfoTime = 0;
-                targetHero = hero;
             }
         }
     }
@@ -413,88 +410,75 @@ public class ChooseControllerPatches
     }
 
     #region 任意传授
-    
-    // 临时存储交互英雄身份等级
-    private static int _tempForceLv = -1;
-    private static int _tempHeroId = -1;
-    
-    
+
     /// <summary>
-    /// 拦截传授技能选择，绕过稀有度限制直接传授给NPC
+    /// 从当前技能选择面板读取玩家刚点中的武功。
+    /// </summary>
+    private static bool TryGetSelectedSkill(out KungfuSkillLvData selectedSkill)
+    {
+        selectedSkill = null!;
+
+        var chooseController = ChooseController.Instance;
+        if (chooseController == null) return false;
+
+        var chooseResult = chooseController.chooseResult;
+        if (chooseResult == null) return false;
+
+        var skillIcon = chooseResult.GetComponent<SkillIconController>();
+        if (skillIcon?.skillLvData == null) return false;
+
+        selectedSkill = skillIcon.skillLvData;
+        return true;
+    }
+
+    /// <summary>
+    /// 只在原版会拦住的“额外技能”上接管点击，并直接调用原版 Sure。
+    /// </summary>
+    private static bool HandleTeachNewSkillChoosen(PlotController plotController, bool forceTeach)
+    {
+        if (plotController == null || !Plugin.Instance.TeachAnyNewSkill.Value) return true;
+
+        var targetInteractHero = plotController.targetInteractHero;
+        if (targetInteractHero == null) return true;
+
+        if (!TryGetSelectedSkill(out var selectedSkill)) return true;
+
+        var skillData = selectedSkill.DataBase();
+        if (skillData == null) return true;
+
+        // 原版允许的技能继续交给游戏自己处理。
+        if (targetInteractHero.FindSkill(selectedSkill.skillID) != null) return true;
+        if (skillData.rareLv != 5 && skillData.rareLv <= targetInteractHero.heroForceLv) return true;
+
+        ChooseController.Instance?.UnshowChoosePanel();
+        var skillIdParam = selectedSkill.skillID.ToString();
+        if (forceTeach)
+            plotController.ForceTeachNewSkillToNPCSure(skillIdParam);
+        else
+            plotController.TeachNewSkillToNPCSure(skillIdParam);
+
+        return false;
+    }
+
+    /// <summary>
+    /// 仅对面板补出来的额外技能接管点击
     /// </summary>
     [HarmonyPrefix]
     [HarmonyPatch(typeof(PlotController), nameof(PlotController.TeachNewSkillToNPCChoosen))]
     public static bool PlotController_TeachNewSkillToNPCChoosen_Prefix(PlotController __instance)
     {
-        
-        if (__instance != null && Plugin.Instance.TeachAnyNewSkill.Value)
-        {
-            var instanceTargetInteractHero = __instance.targetInteractHero;
-            
-            if (instanceTargetInteractHero == null) return true;
-            instanceTargetInteractHero.heroForceLv = _tempForceLv;
-            _tempForceLv = -1;
-            var chooseController = ChooseController.Instance;
-            if (chooseController == null) return true;
-            
-            var chooseResult = chooseController.chooseResult;
-            if (chooseResult == null) return true;
-            
-            var skillIcon = chooseResult.GetComponent<SkillIconController>();
-            if (skillIcon == null) return true;
-            
-            var selectedSkill = skillIcon.skillLvData;
-            if (selectedSkill == null) return true;
-            
-            if (instanceTargetInteractHero.FindSkill(selectedSkill.skillID) != null) return false;
-            
-            var npcSkills = instanceTargetInteractHero.kungfuSkills;
-            if (npcSkills == null) return false;
-            
-            var newSkill = new KungfuSkillLvData(selectedSkill.skillID);
-            instanceTargetInteractHero.GetSkill(newSkill, true, true);
-            // targetHero.ChangeFavor(20, true, successSound:true);
-            __instance.ChangeTargetInteractHeroFavor("20");
-            
-            if (Plugin.Instance.TeachNewSkillToNpc.Value)
-            {
-                var skill = instanceTargetInteractHero.FindSkill(newSkill.skillID);
-                for (int i = 0; i < 10; i++)
-                {
-                    instanceTargetInteractHero.UpgradeSkill(skill);
-                }
-            }
-            __instance.HideInteractUI();
-            return false;
-        }
-
-        return true;
+        return HandleTeachNewSkillChoosen(__instance, false);
     }
+
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(PlotController), nameof(PlotController.TeachNewSkillToNPC))]
-    public static void TeachNewSkillToNPC_Prefix(PlotController __instance)
+    [HarmonyPatch(typeof(PlotController), nameof(PlotController.ForceTeachNewSkillToNPCChoosen))]
+    public static bool PlotController_ForceTeachNewSkillToNPCChoosen_Prefix(PlotController __instance)
     {
-        if (__instance == null || !Plugin.Instance.TeachAnyNewSkill.Value) return;
-        var targetInteractHero = __instance.targetInteractHero;
-        if (targetInteractHero == null) return;
-        targetHero = targetInteractHero;
-        _tempForceLv = targetInteractHero.heroForceLv;
-        _tempHeroId = targetInteractHero.heroID;
-        targetInteractHero.heroForceLv = 5;
-    }
-
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(ChooseController), nameof(ChooseController.UnshowChoosePanel))]
-    public static void ChooseController_UnshowChoosePanel_Postfix(ChooseController __instance)
-    {
-        var flag = HeroHelper.TryGetHeroByID(_tempHeroId, out var hero);
-        if (__instance == null || !flag) return;
-        _tempHeroId = -1;
-        hero.heroForceLv = _tempForceLv;
+        return HandleTeachNewSkillChoosen(__instance, true);
     }
     
     /// <summary>
-    /// 在技能选择面板显示后，添加被过滤掉技能
+    /// 只补技能选择面板，让原版没有列出的武功也能出现在列表里。
     /// </summary>
     [HarmonyPostfix]
     [HarmonyPatch(typeof(ChooseController), nameof(ChooseController.ShowChoosePanel),
@@ -559,6 +543,8 @@ public class ChooseControllerPatches
             Plugin.LOG.Msg(_filterType);
             var player = GameDataController.Instance?.gameSaveData?.WorldData?.Player();
             if (player == null || player.kungfuSkills == null) return;
+            // 优先使用当前选择流程传入的目标，避免静态缓存串到别的 NPC。
+            var currentTargetHero = targetFavorHero ?? PlotController.Instance?.targetInteractHero;
             
             var content = __instance.choosePanel?.transform?.Find("ChoosePanelRoot/ChooseItemList/Viewport/Content");
             if (content == null) return;
@@ -584,9 +570,9 @@ public class ChooseControllerPatches
                 }
             }
             var npcExistingSkillIds = new System.Collections.Generic.HashSet<int>();
-            if (targetHero is { kungfuSkills: not null })
+            if (currentTargetHero is { kungfuSkills: not null })
             {
-                foreach (var skill in targetHero.kungfuSkills)
+                foreach (var skill in currentTargetHero.kungfuSkills)
                 {
                     if (skill != null)
                     {
@@ -597,7 +583,8 @@ public class ChooseControllerPatches
             
             foreach (var skill in player.kungfuSkills)
             {
-                if (skill == null || existingSkillIds.Contains(skill.skillID) || skill.DataBase().rareLv < 5) continue;
+                // 这里不再限制 rareLv，真正做到“任意等级技能”都能补进列表。
+                if (skill == null || existingSkillIds.Contains(skill.skillID)) continue;
                 if (npcExistingSkillIds.Contains(skill.skillID)) continue;
             
                 var skillData = skill.DataBase();
@@ -1255,18 +1242,29 @@ public class PlotControllerPatches
     }
     
     
+    /// <summary>
+    /// 统一处理“传授后直接升满”，顺便兜住目标技能不存在的情况。
+    /// </summary>
+    private static void UpgradeTargetSkillToFull(HeroData targetHero, string skillIDParam)
+    {
+        if (targetHero == null || string.IsNullOrWhiteSpace(skillIDParam)) return;
+
+        var targetSkill = targetHero.FindSkill(int.Parse(skillIDParam));
+        if (targetSkill == null) return;
+
+        for (int i = 0; i < 10; i++)
+        {
+            targetHero.UpgradeSkill(targetSkill);
+        }
+    }
+
     [HarmonyPostfix]
     [HarmonyPatch(typeof(PlotController), nameof(PlotController.TeachNewSkillToNPCSure))]
     public static void PlotController_TeachNewSkillToNPCSure_Postfix(PlotController __instance, string skillIDParam)
     {
         if (__instance != null && Plugin.Instance.TeachNewSkillToNpc.Value)
         {
-            var a = __instance.targetInteractHero;
-            var b = a.FindSkill(int.Parse(skillIDParam));
-            for (int i = 0; i < 10; i++)
-            {
-                a.UpgradeSkill(b);
-            }
+            UpgradeTargetSkillToFull(__instance.targetInteractHero, skillIDParam);
         }
     }
 
@@ -1276,12 +1274,7 @@ public class PlotControllerPatches
     {
         if (__instance != null && Plugin.Instance.TeachNpc.Value)
         {
-            var a = __instance.targetInteractHero;
-            var b = a.FindSkill(int.Parse(skillIDParam));
-            for (int i = 0; i < 10; i++)
-            {
-                a.UpgradeSkill(b);
-            }
+            UpgradeTargetSkillToFull(__instance.targetInteractHero, skillIDParam);
         }
     }
     
@@ -1291,28 +1284,18 @@ public class PlotControllerPatches
     {
         if (__instance != null && Plugin.Instance.TeachNpc.Value)
         {
-            var a = __instance.targetInteractHero;
-            var b = a.FindSkill(int.Parse(skillIDParam));
-            for (int i = 0; i < 10; i++)
-            {
-                a.UpgradeSkill(b);
-            }
+            UpgradeTargetSkillToFull(__instance.targetInteractHero, skillIDParam);
         }
     }
     [HarmonyPostfix]
     [HarmonyPatch(typeof(PlotController), nameof(PlotController.ForceTeachNewSkillToNPCSure))]
     public static void PlotController_ForceTeachNewSkillToNPCSure_Postfix(PlotController __instance, string skillIDParam)
     {
-        if (__instance != null && Plugin.Instance.TeachNpc.Value)
+        if (__instance != null && Plugin.Instance.TeachNewSkillToNpc.Value)
         {
-            var a = __instance.targetInteractHero;
-            var b = a.FindSkill(int.Parse(skillIDParam));
-            for (int i = 0; i < 10; i++)
-            {
-                a.UpgradeSkill(b);
-            }
+            UpgradeTargetSkillToFull(__instance.targetInteractHero, skillIDParam);
             if (Plugin.Instance.Interaction.Value) 
-                a.playerInteractionTimeData.ResetTime();
+                __instance.targetInteractHero?.playerInteractionTimeData?.ResetTime();
         }
     }
 }


### PR DESCRIPTION
## 变更内容
- 修正任意传授时的技能面板补全逻辑，使原版未列出的可传授武功也能显示出来
- 仅在额外补出的技能会被原版选择流程拦截时接管点击，并直接调用原版确认逻辑
- 改为优先使用当前交互流程传入的目标角色，移除静态缓存目标角色和临时修改 heroForceLv 的做法
- 抽取传授后升满技能的公共逻辑，并修正强制传授新武功分支使用的配置开关与交互次数重置处理

## 变更原因
之前的实现依赖临时提升目标角色身份等级和静态缓存目标角色来绕过原版限制。这种做法容易带来串目标、状态残留，以及确认流程和原版 UI 分叉的问题。

## 影响
- 任意传授面板展示更完整
- 额外技能的确认流程更贴近原版行为
- 降低交互状态污染风险
- 统一传授后升满技能逻辑，减少分支不一致

## 验证
- 构建通过，0 error，存在既有 nullable warning
- 现在选完要传授的技能后会直接弹出成功的结果
